### PR TITLE
Multiple DNS support. Configurable proxy and TTL. Cleanup

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"strconv"
 
 	cloudflare "github.com/cloudflare/cloudflare-go"
 	"github.com/pkg/errors"
@@ -21,17 +22,23 @@ import (
 var options = struct {
 	CloudflareAPIEmail string
 	CloudflareAPIKey   string
+	CloudflareProxy    string
+	CloudflareTTL			 string
 	DNSName            string
 }{
 	CloudflareAPIEmail: os.Getenv("CF_API_EMAIL"),
 	CloudflareAPIKey:   os.Getenv("CF_API_KEY"),
+	CloudflareProxy:    os.Getenv("CF_PROXY"),
+	CloudflareTTL:      os.Getenv("CF_TTL"),
 	DNSName:            os.Getenv("DNS_NAME"),
 }
 
 func main() {
-	flag.StringVar(&options.DNSName, "dns-name", options.DNSName, "the dns name to use for the nodes")
+	flag.StringVar(&options.DNSName, "dns-name", options.DNSName, "the dns name for the nodes, comma-separated for multiple (same root)")
 	flag.StringVar(&options.CloudflareAPIEmail, "cloudflare-api-email", options.CloudflareAPIEmail, "the email address to use for cloudflare")
 	flag.StringVar(&options.CloudflareAPIKey, "cloudflare-api-key", options.CloudflareAPIKey, "the key to use for cloudflare")
+	flag.StringVar(&options.CloudflareProxy, "cloudflare-proxy", options.CloudflareProxy, "enable cloudflare proxy on dns (default false)")
+	flag.StringVar(&options.CloudflareTTL, "cloudflare-ttl", options.CloudflareTTL, "ttl for dns (default 120)")
 	flag.Parse()
 
 	if options.CloudflareAPIEmail == "" {
@@ -42,9 +49,23 @@ func main() {
 		flag.Usage()
 		log.Fatalln("cloudflare api key is required")
 	}
-	if options.DNSName == "" {
+
+	dnsNames := strings.Split(options.DNSName, ",")
+	if len(dnsNames) == 1 && dnsNames[0] == "" {
 		flag.Usage()
-		log.Fatalln("dns name is required", options.DNSName)
+		log.Fatalln("dns name is required")
+	}
+
+	cloudflareProxy, err := strconv.ParseBool(options.CloudflareProxy)
+	if err != nil {
+		log.Println("CloudflareProxy config not found or incorrect, defaulting to false")
+		cloudflareProxy = false
+	}
+
+	cloudflareTTL, err := strconv.Atoi(options.CloudflareTTL)
+	if err != nil {
+		log.Println("CloudflareTTL config not found or incorrect, defaulting to 120")
+		cloudflareTTL = 120
 	}
 
 	cfg, err := rest.InClusterConfig()
@@ -86,7 +107,7 @@ func main() {
 		}
 		lastIPs = ips
 
-		err = sync(ips)
+		err = sync(ips, dnsNames, cloudflareTTL, cloudflareProxy)
 		if err != nil {
 			log.Fatalln("failed to sync", err)
 		}
@@ -109,13 +130,13 @@ func main() {
 	select {}
 }
 
-func sync(ips []string) error {
+func sync(ips []string, dnsNames []string, cloudflareTTL int, cloudflareProxy bool) error {
 	api, err := cloudflare.New(options.CloudflareAPIKey, options.CloudflareAPIEmail)
 	if err != nil {
 		return errors.Wrap(err, "failed to access cloudflare api")
 	}
 
-	root := options.DNSName
+	root := dnsNames[0]
 	for strings.Count(root, ".") > 1 {
 		root = root[strings.Index(root, ".")+1:]
 	}
@@ -126,59 +147,69 @@ func sync(ips []string) error {
 			root)
 	}
 
-	records, err := api.DNSRecords(zoneID, cloudflare.DNSRecord{})
-	if err != nil {
-		return errors.Wrapf(err, "failed to list dns records for zone-id=%s",
-			zoneID)
-	}
-
 	known := map[string]bool{}
 	for _, ip := range ips {
 		known[ip] = true
 	}
-	seen := map[string]bool{}
-	var remove []string
 
-	for _, record := range records {
-		if record.Type == "A" &&
-			record.Name == options.DNSName {
-			log.Printf("found existing record name=%s type=%s content=%s\n",
-				record.Name, record.Type, record.Content)
+	for _, dnsName := range dnsNames {
+		records, err := api.DNSRecords(zoneID, cloudflare.DNSRecord{Type: "A", Name: dnsName})
+		if err != nil {
+			return errors.Wrapf(err, "failed to list dns records for zone-id=%s name=%s",
+				zoneID, dnsName)
+		}
+
+		seen := map[string]bool{}
+
+		for _, record := range records {
+			log.Printf("found existing record name=%s ip=%s\n",
+				record.Name, record.Content)
 			if _, ok := known[record.Content]; ok {
 				seen[record.Content] = true
+
+				if record.Proxied != cloudflareProxy || record.TTL != cloudflareTTL {
+					log.Printf("updating dns record name=%s ip=%s\n",
+						record.Name, record.Content)
+					err := api.UpdateDNSRecord(zoneID, record.ID, cloudflare.DNSRecord{
+						Type:    record.Type,
+						Name:    record.Name,
+						Content: record.Content,
+						TTL:     cloudflareTTL,
+						Proxied: cloudflareProxy,
+					})
+					if err != nil {
+						return errors.Wrapf(err, "failed to update dns record zone-id=%s record-id=%s name=%s ip=%s",
+							zoneID, record.ID, record.Name, record.Content)
+					}
+				}
 			} else {
-				remove = append(remove, record.ID)
+				log.Printf("removing dns record name=%s ip=%s\n",
+					record.Name, record.Content)
+				err := api.DeleteDNSRecord(zoneID, record.ID)
+				if err != nil {
+					return errors.Wrapf(err, "failed to delete dns record zone-id=%s record-id=%s name=%s ip=%s",
+						zoneID, record.ID, record.Name, record.Content)
+				}
 			}
 		}
-	}
 
-	for ip := range known {
-		if _, ok := seen[ip]; ok {
-			continue
-		}
-		log.Printf("adding dns record zone-id=%s ip=%s\n",
-			zoneID, ip)
-
-		_, err := api.CreateDNSRecord(zoneID, cloudflare.DNSRecord{
-			Type:    "A",
-			Name:    options.DNSName,
-			Content: ip,
-			TTL:     120,
-			Proxied: false,
-		})
-		if err != nil {
-			return errors.Wrapf(err, "failed to create dns record zone-id=%s name=%s ip=%s",
-				zoneID, options.DNSName, ip)
-		}
-	}
-
-	for _, recordID := range remove {
-		log.Printf("removing dns record zone-id=%s record-id=%s\n",
-			zoneID, recordID)
-		err := api.DeleteDNSRecord(zoneID, recordID)
-		if err != nil {
-			return errors.Wrapf(err, "failed to delete dns record zone-id=%s record-id=%s",
-				zoneID, recordID)
+		for ip := range known {
+			if _, ok := seen[ip]; ok {
+				continue
+			}
+			log.Printf("adding dns record name=%s ip=%s\n",
+				dnsName, ip)
+			_, err := api.CreateDNSRecord(zoneID, cloudflare.DNSRecord{
+				Type:    "A",
+				Name:    dnsName,
+				Content: ip,
+				TTL:     cloudflareTTL,
+				Proxied: cloudflareProxy,
+			})
+			if err != nil {
+				return errors.Wrapf(err, "failed to create dns record zone-id=%s name=%s ip=%s",
+					zoneID, dnsName, ip)
+			}
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -67,6 +67,8 @@ func main() {
 		log.Println("CloudflareTTL config not found or incorrect, defaulting to 120")
 		cloudflareTTL = 120
 	}
+	
+	log.SetOutput(os.Stdout)
 
 	cfg, err := rest.InClusterConfig()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ var options = struct {
 	CloudflareAPIEmail string
 	CloudflareAPIKey   string
 	CloudflareProxy    string
-	CloudflareTTL			 string
+	CloudflareTTL	   string
 	DNSName            string
 }{
 	CloudflareAPIEmail: os.Getenv("CF_API_EMAIL"),


### PR DESCRIPTION
Thx for open-sourcing this, was hacking around with the external-dns controller but this is so much easier and lightweight with essentially the same outcome.

Was reading your affordable k8s blog post today and I thought I'd give it a try, but I had to modify it a bit to be able to configure multiple DNS records as I'm using the same ingress controller and also Cloudflare proxy/TTL. Also published the Docker image to `quay.io/adrianchifor/kubernetes-cloudflare-sync:master` in case you want to test.