### PR TITLE
Fix typing of options struct.

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ var options = struct {
 	CloudflareTTL      string
 	DNSName            string
 	UseInternalIP      bool
+  SkipExternalIP     bool
 	NodeSelector       string
 }{
 	CloudflareAPIEmail: os.Getenv("CF_API_EMAIL"),


### PR DESCRIPTION
This was seemingly missed out of #16 so now the build fails.